### PR TITLE
Feature: Haptics and Sensitivity

### DIFF
--- a/MacDial/Dial.swift
+++ b/MacDial/Dial.swift
@@ -277,6 +277,7 @@ class Dial
                 print("Trying to open device...")
                 if device.connect() {
                     print("Device \(device.serialNumber) opened.")
+                    device.updateSensitivity() // thanks @bernhard-adobe
                 } else {
                     print("Device couldn't be opened.")
                 }


### PR DESCRIPTION
# Description

Enabled haptics by sending an HID message to the dial. This feature also introduces a change to how sensitivity works. Previously sensitivity increased or decreased the number of lines scrolled or amount of volume change, but did not truly change how sensitive the dial was. Now it works like changing the DPI setting on a mouse; it increases the amount of events generated per angle physically rotated. This way the haptics match the sensitivity.

Some changes may be necessary to retune the `multiplier` value in `ScrollController`.

Fixes #15 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Launching mac-dial restores previous settings. Quitting mac-dial turns off haptics and restores the default sensitivity. Changing sensitivity and enabling/disabling haptics works as expected. Project generates no new errors and uses general architecture of original project to achieve the feature.