### PR TITLE
Fix menu bar icon and build compatibility for macOS 26

### DIFF
--- a/MacDial/StatusBarController.swift
+++ b/MacDial/StatusBarController.swift
@@ -149,7 +149,7 @@ class StatusBarController
             case .some("playback"):
                 return .playback
             default:
-                return .scrolling
+                return .playback
             }
         }
         
@@ -258,7 +258,7 @@ class StatusBarController
         self.dial = dial
         self.menu = NSMenu.init()
         
-        statusBar = NSStatusBar.init()
+        statusBar = NSStatusBar.system
         statusItem = statusBar.statusItem(withLength: NSStatusItem.variableLength)
         
         menu.minimumWidth = 260

--- a/build_hidapi.sh
+++ b/build_hidapi.sh
@@ -3,12 +3,12 @@ cd lib/hidapi/
 
 mkdir -p build
 cd build
-cmake .. -DBUILD_SHARED_LIBS=false
+cmake .. -DBUILD_SHARED_LIBS=false -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 make
 
 cd ..
 mkdir -p build_x86
 cd build_x86
-cmake .. -DBUILD_SHARED_LIBS=false -DCMAKE_C_FLAGS="-target x86_64-apple-macos10.15 -arch x86_64" -DCMAKE_EXE_LINKER_FLAGS="-target x86_64-apple-macos10.15"
+cmake .. -DBUILD_SHARED_LIBS=false -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_C_FLAGS="-target x86_64-apple-macos10.15 -arch x86_64" -DCMAKE_EXE_LINKER_FLAGS="-target x86_64-apple-macos10.15"
 make
 


### PR DESCRIPTION
## Summary

- **Menu bar icon missing on macOS 26**: `NSStatusBar.init()` creates a private orphaned status bar that never appears in the menu bar. Fixed by using `NSStatusBar.system` (the shared system singleton) instead.
- **Build failure with modern cmake**: `build_hidapi.sh` now passes `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to cmake to fix a hard error introduced in recent cmake versions.
- **Default mode changed to Playback**: First-launch default is now Playback mode (volume + play/pause) instead of Scroll mode, which is the more common use case for the dial.

## Test plan

- [x] Build on macOS 26 with modern cmake — `build_hidapi.sh` completes without error
- [x] App launches and menu bar icon is visible in top-right menu bar
- [x] Playback mode: rotating dial changes system volume, clicking dial sends play/pause
- [x] Scroll mode: rotating dial scrolls, clicking sends mouse click

Tested on macOS 26.3.1 (25D2128), Apple Silicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)